### PR TITLE
further fix livekit autoupdate

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -78,6 +78,9 @@ ram.runtime = "200M"
     in_subdir=false
     autoupdate.strategy = "latest_github_release"
     autoupdate.upstream = "https://github.com/livekit/livekit"
+    autoupdate.asset.amd64 = ".*amd64.tar.gz"
+    autoupdate.asset.arm64 = ".*arm64.tar.gz"
+    autoupdate.asset.armhf = ".*armv7.tar.gz"
 
     [resources.system_user]
 


### PR DESCRIPTION
## Problem

- *Description of why you made this PR*

```
Checking livekit ...

It looks like there's an inconsistency between the old asset list and the new ones... One is arch-specific, the other is not... Did you forget to define arch-specific regexes? New asset url is/are : https://github.com/livekit/livekit/archive/refs/tags/v1.9.10.tar.gz
```


## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
