### PR TITLE
[WAITING REVIEW FROM SPECIFIC PERSON] Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simple and Secure Video Conferencing
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://visio.numerique.gouv.fr/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://visio.numerique.gouv.fr/)
-[![Version: 1.21.0~ynh1](https://img.shields.io/badge/Version-1.21.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/lasuite-meet/)
+[![Version: 1.21.0~ynh2](https://img.shields.io/badge/Version-1.21.0~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/lasuite-meet/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/lasuite-meet"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simple and Secure Video Conferencing
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://visio.numerique.gouv.fr/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://visio.numerique.gouv.fr/)
-[![Version: 1.21.0~ynh2](https://img.shields.io/badge/Version-1.21.0~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/lasuite-meet/)
+[![Version: 1.22.0~ynh1](https://img.shields.io/badge/Version-1.22.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/lasuite-meet/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/lasuite-meet"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/livekit.yaml
+++ b/conf/livekit.yaml
@@ -11,7 +11,10 @@ rtc:
     port_range_end: 65535
     tcp_port: __PORT_TCP__
     turn_servers: null
-    use_external_ip: true
+    use_external_ip: false
+    # FIXME: probably better switch to coturn?
+    stun_servers:
+      - stun.nextcloud.com:443
 
 turn:
     enabled: true

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "La Suite - Meet"
 description.en = "Simple and Secure Video Conferencing"
 description.fr = "Solution simple et sécurisée de visioconférence"
 
-version = "1.21.0~ynh1"
+version = "1.21.0~ynh2"
 
 maintainers = ["fflorent", "rouja"]
 
@@ -69,12 +69,12 @@ ram.runtime = "200M"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.sources.livekit]
-    amd64.url = "https://github.com/livekit/livekit/releases/download/v1.13.1/livekit_1.13.1_linux_amd64.tar.gz"
-    amd64.sha256 = "e9f70e2e44f8fbe1c5ad109087d44964d2afebfccfe0e8282a92215cf332e028"
-    arm64.url = "https://github.com/livekit/livekit/releases/download/v1.13.1/livekit_1.13.1_linux_arm64.tar.gz"
-    arm64.sha256 = "59245ecffe27d82435d9389e51e9c54e978254eb2290c53d46a81543754d6c59"
-    armhf.url = "https://github.com/livekit/livekit/releases/download/v1.13.1/livekit_1.13.1_linux_armv7.tar.gz"
-    armhf.sha256 = "5a39af6260e0a39c62e57750f260b364f39099f3912291e97eac2f3d09725d8a"
+    amd64.url = "https://github.com/livekit/livekit/releases/download/v1.13.2/livekit_1.13.2_linux_amd64.tar.gz"
+    amd64.sha256 = "8198b465f84a358caaf2ae322d6fece55991276f3b2f818e4a1241d5f9e13d09"
+    arm64.url = "https://github.com/livekit/livekit/releases/download/v1.13.2/livekit_1.13.2_linux_arm64.tar.gz"
+    arm64.sha256 = "5c20d6cdb85affaa5098ec8a39eb9b5def9391b66d684a42cb96eec2371f200e"
+    armhf.url = "https://github.com/livekit/livekit/releases/download/v1.13.2/livekit_1.13.2_linux_armv7.tar.gz"
+    armhf.sha256 = "d1f7518f04323fc2a4adfc00b77b0e69e18405808cb525c8e5c5baa0b432912a"
     in_subdir=false
     autoupdate.strategy = "latest_github_release"
     autoupdate.upstream = "https://github.com/livekit/livekit"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "La Suite - Meet"
 description.en = "Simple and Secure Video Conferencing"
 description.fr = "Solution simple et sécurisée de visioconférence"
 
-version = "1.21.0~ynh2"
+version = "1.22.0~ynh1"
 
 maintainers = ["fflorent", "rouja"]
 
@@ -64,17 +64,17 @@ ram.runtime = "200M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/suitenumerique/meet/archive/refs/tags/v1.21.0.tar.gz"
-    sha256 = "4bc6d6dc0d1c3b42fbe93c76e34b6c03d6e8d91dd341fdd5fcf4741810208701"
+    url = "https://github.com/suitenumerique/meet/archive/refs/tags/v1.22.0.tar.gz"
+    sha256 = "7624109c7314328fb6695f3e2f4ddb6a7be603de446ddf93ad7afe50d43a738d"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.sources.livekit]
-    amd64.url = "https://github.com/livekit/livekit/releases/download/v1.13.2/livekit_1.13.2_linux_amd64.tar.gz"
-    amd64.sha256 = "8198b465f84a358caaf2ae322d6fece55991276f3b2f818e4a1241d5f9e13d09"
-    arm64.url = "https://github.com/livekit/livekit/releases/download/v1.13.2/livekit_1.13.2_linux_arm64.tar.gz"
-    arm64.sha256 = "5c20d6cdb85affaa5098ec8a39eb9b5def9391b66d684a42cb96eec2371f200e"
-    armhf.url = "https://github.com/livekit/livekit/releases/download/v1.13.2/livekit_1.13.2_linux_armv7.tar.gz"
-    armhf.sha256 = "d1f7518f04323fc2a4adfc00b77b0e69e18405808cb525c8e5c5baa0b432912a"
+    amd64.url = "https://github.com/livekit/livekit/releases/download/v1.13.3/livekit_1.13.3_linux_amd64.tar.gz"
+    amd64.sha256 = "7ac9372a229b3d31a716d63b5a9915ad2ffb7d28a8bacc5ba5fc33a2a475d8a3"
+    arm64.url = "https://github.com/livekit/livekit/releases/download/v1.13.3/livekit_1.13.3_linux_arm64.tar.gz"
+    arm64.sha256 = "b76fa445c625827999ab6a8cd2d30a64547cb3c9e7189b64ab1dd7444bc17159"
+    armhf.url = "https://github.com/livekit/livekit/releases/download/v1.13.3/livekit_1.13.3_linux_armv7.tar.gz"
+    armhf.sha256 = "e6a2c5be24085b16492564847f300cac2918a261088d875aff1658a1b268ebe4"
     in_subdir=false
     autoupdate.strategy = "latest_github_release"
     autoupdate.upstream = "https://github.com/livekit/livekit"


### PR DESCRIPTION
## Problem

- needs upgrade
- Error message: "failed to get external ip"
- By default, livekit uses Google Stun server :(

## Solution

- Upgrade to latest versions of Livekit and Lasuite Meet
- Set `use_external_ip: false` as suggested in this issue: https://github.com/livekit/livekit/issues/3157
- Use nextcloud stun server

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
