### PR TITLE
Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simple and Secure Video Conferencing
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://visio.numerique.gouv.fr/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://visio.numerique.gouv.fr/)
-[![Version: 1.24.0~ynh1](https://img.shields.io/badge/Version-1.24.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/lasuite-meet/)
+[![Version: 1.24.0~ynh2](https://img.shields.io/badge/Version-1.24.0~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/lasuite-meet/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/lasuite-meet"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/systemd-livekit.service
+++ b/conf/systemd-livekit.service
@@ -10,6 +10,8 @@ WorkingDirectory=__INSTALL_DIR__/
 ExecStart=__INSTALL_DIR__/livekit/livekit-server --config __INSTALL_DIR__/livekit/livekit.yaml
 StandardOutput=append:/var/log/__APP__/__APP__-livekit.log
 StandardError=inherit
+Restart=on-failure
+RestartSec=10s
 
 ### Depending on specificities of your service/app, you may need to tweak these
 ### .. but this should be a good baseline

--- a/conf/systemd-livekit.service
+++ b/conf/systemd-livekit.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Livekit for __APP__
-After=network.target
+After=network.target dnsmasq.service
 
 [Service]
 Type=simple

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "La Suite - Meet"
 description.en = "Simple and Secure Video Conferencing"
 description.fr = "Solution simple et sécurisée de visioconférence"
 
-version = "1.24.0~ynh1"
+version = "1.24.0~ynh2"
 
 maintainers = ["fflorent", "rouja"]
 
@@ -69,12 +69,12 @@ ram.runtime = "200M"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.sources.livekit]
-    amd64.url = "https://github.com/livekit/livekit/releases/download/v1.13.4/livekit_1.13.4_linux_amd64.tar.gz"
-    amd64.sha256 = "549bcbe07a92685e45dfd98d8e7cbafd0e1c91d3502fd417079162e1a3f18d17"
-    arm64.url = "https://github.com/livekit/livekit/releases/download/v1.13.4/livekit_1.13.4_linux_arm64.tar.gz"
-    arm64.sha256 = "691d34c0d0095a3d5c6dfb9d7e9353a0600a3423d498136037001626d281ad64"
-    armhf.url = "https://github.com/livekit/livekit/releases/download/v1.13.4/livekit_1.13.4_linux_armv7.tar.gz"
-    armhf.sha256 = "a81b785b3951780f4f7e3fd62c02cefac827c40a4763513834e5ebff7b9d8a39"
+    amd64.url = "https://github.com/livekit/livekit/releases/download/v1.13.5/livekit_1.13.5_linux_amd64.tar.gz"
+    amd64.sha256 = "c020fac437b7cc9b776eef1ad5ea8af77be9acfa07602eca20a3a44930dfbc70"
+    arm64.url = "https://github.com/livekit/livekit/releases/download/v1.13.5/livekit_1.13.5_linux_arm64.tar.gz"
+    arm64.sha256 = "332015305518765fe05bad74fc3a9d9583e635e7dd130de3c4fc563d69c550f3"
+    armhf.url = "https://github.com/livekit/livekit/releases/download/v1.13.5/livekit_1.13.5_linux_armv7.tar.gz"
+    armhf.sha256 = "6dceb15fec3b2b90a67615acff7f92a48a901408f31c74f3d290a7d4277f76bd"
     in_subdir=false
     autoupdate.strategy = "latest_github_release"
     autoupdate.upstream = "https://github.com/livekit/livekit"


### PR DESCRIPTION
## Problem

- livekit is a bit outdated
- livekit might not start due to dnsmasq not being ready
- when livekit crash, the videoconferencing does not work anymore until the administrator restarts manually the service

## Solution

Fixes #109 

- update livekit to version 1.13.5
- start dnsmasq once livekit is ready
- restart the service on failure

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
