### PR TITLE
Issue 108

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simple and Secure Video Conferencing
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://visio.numerique.gouv.fr/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://visio.numerique.gouv.fr/)
-[![Version: 1.25.2~ynh1](https://img.shields.io/badge/Version-1.25.2~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/lasuite-meet/)
+[![Version: 1.25.2~ynh2](https://img.shields.io/badge/Version-1.25.2~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/lasuite-meet/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/lasuite-meet"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/livekit.yaml.j2
+++ b/conf/livekit.yaml.j2
@@ -1,15 +1,15 @@
 # Documentation: https://docs.livekit.io/home/self-hosting/deployment/#configuration
 keys:
-    meet: __LIVEKIT_SECRET_KEY__
+    meet: {{ livekit_secret_key }}
 log_level: info
-port: __PORT_LIVEKIT__
+port: {{ port_livekit }}
 redis:
     address: localhost:6379
-    db: __REDIS_DB__
+    db: {{ redis_db }}
 rtc:
     port_range_start: 49152
     port_range_end: 65535
-    tcp_port: __PORT_TCP__
+    tcp_port: {{ port_tcp }}
     turn_servers: null
     use_external_ip: false
     # FIXME: probably better switch to coturn?
@@ -18,7 +18,7 @@ rtc:
 
 turn:
     enabled: true
-    domain: __TURN_DOMAIN__
-    tls_port: __PORT_TURN__
-    udp_port: __PORT_TURN_UDP__
+    domain: {{ turn_domain }}
+    tls_port: {{ port_turn }}
+    udp_port: {{ port_turn_udp }}
     external_tls: true

--- a/conf/livekit.yaml.j2
+++ b/conf/livekit.yaml.j2
@@ -11,7 +11,8 @@ rtc:
     port_range_end: 65535
     tcp_port: {{ port_tcp }}
     turn_servers: null
-    use_external_ip: false
+    use_external_ip: {{ 'true' if livekit_network_mode in ['internet', 'both'] else 'false' }}
+    advertise_internal_ip: {{ 'true' if livekit_network_mode == 'both' else 'false' }}
     # FIXME: probably better switch to coturn?
     stun_servers:
       - stun.nextcloud.com:443

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -25,19 +25,23 @@ services = [ "__APP__-livekit" ] # Restart livekit when applying configuration i
         choices.local = "Local network only"
         choices.internet = "Internet access only"
         choices.both = "Local network and Internet"
+        optional = false
         default = "both"
-        bind = "null"
-        help.en = """\
+        help = """\
 - **Local network only**: for installations only used from a local network or through a VPN. The server isn't exposed to the Internet and no public LiveKit ports are forwarded (livekit config: `use_external_ip: false`, `advertise_internal_ip: false`).
 
 - **Internet access only**: for a server with a public IP address (e.g. a VPS) where participants mainly connect from the Internet, with the required LiveKit ports forwarded. May not work correctly for local participants if the router doesn't support NAT loopback/hairpinning (livekit config: `use_external_ip: true`, `advertise_internal_ip: false`).
 
 - **Local network and Internet**: for a server behind a home/office router with port forwarding, reached both from the local network and from the Internet (mobile data, etc). This is usually the right choice if the router doesn't correctly support NAT loopback (livekit config: `use_external_ip: true`, `advertise_internal_ip: true`).\
 """
-        help.fr = """\
-- **Local network only (Réseau local uniquement)** : pour les installations utilisées uniquement depuis un réseau local ou via un VPN. Le serveur n'est pas exposé sur Internet et aucun port LiveKit public n'est redirigé (configuration livekit : `use_external_ip: false`, `advertise_internal_ip: false`).
-
-- **Internet access only (Accès Internet uniquement)** : pour un serveur avec une adresse IP publique (VPS par exemple) où les participants se connectent principalement depuis Internet, avec les ports LiveKit nécessaires redirigés. Peut ne pas fonctionner correctement pour les participants locaux si le routeur ne supporte pas le NAT loopback/hairpin (configuration livekit : `use_external_ip: true`, `advertise_internal_ip: false`).
-
-- **Local network and Internet (Réseau local et Internet)** : pour un serveur derrière une box/un routeur avec redirection de ports, accessible à la fois depuis le réseau local et depuis Internet (4G, etc). C'est en général le bon choix si le routeur ne supporte pas correctement le NAT loopback (configuration livekit : `use_external_ip: true`, `advertise_internal_ip: true`).\
-"""
+#         FIXME: We should provide translations, but it looks like Yunohost
+#         Does not support localized multi-line strings.
+#
+#
+#         help.fr = """\
+# - **Local network only (Réseau local uniquement)** : pour les installations utilisées uniquement depuis un réseau local ou via un VPN. Le serveur n'est pas exposé sur Internet et aucun port LiveKit public n'est redirigé (configuration livekit : `use_external_ip: false`, `advertise_internal_ip: false`).
+#
+# - **Internet access only (Accès Internet uniquement)** : pour un serveur avec une adresse IP publique (VPS par exemple) où les participants se connectent principalement depuis Internet, avec les ports LiveKit nécessaires redirigés. Peut ne pas fonctionner correctement pour les participants locaux si le routeur ne supporte pas le NAT loopback/hairpin (configuration livekit : `use_external_ip: true`, `advertise_internal_ip: false`).
+#
+# - **Local network and Internet (Réseau local et Internet)** : pour un serveur derrière une box/un routeur avec redirection de ports, accessible à la fois depuis le réseau local et depuis Internet (4G, etc). C'est en général le bon choix si le routeur ne supporte pas correctement le NAT loopback (configuration livekit : `use_external_ip: true`, `advertise_internal_ip: true`).\
+# """

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,0 +1,37 @@
+#:schema https://github.com/YunoHost/apps/raw/main/schemas/config_panel.v1.schema.json
+
+version = "1.0"
+
+[main]
+name.en = "LiveKit network"
+name.fr = "Réseau LiveKit"
+
+    [main.network]
+    name.en = "Network mode"
+    name.fr = "Mode réseau"
+    help.en = "Choose how LiveKit should advertise its address to participants, depending on how this server is reachable on the network. Changing this only restarts the LiveKit service."
+    help.fr = "Choisissez comment LiveKit doit annoncer son adresse aux participants, en fonction de la façon dont ce serveur est accessible sur le réseau. Ce changement ne redémarre que le service LiveKit."
+
+        [main.network.livekit_network_mode]
+        ask.en = "LiveKit network mode"
+        ask.fr = "Mode réseau LiveKit"
+        type = "select"
+        choices.local = "Local network only"
+        choices.internet = "Internet access only"
+        choices.both = "Local network and Internet"
+        default = "local"
+        bind = "null"
+        help.en = """\
+- **Local network only** (`use_external_ip: false`, `advertise_internal_ip: false`): for installations only used from a local network or through a VPN. The server isn't exposed to the Internet and no public LiveKit ports are forwarded.
+
+- **Internet access only** (`use_external_ip: true`, `advertise_internal_ip: false`): for a server with a public IP address (e.g. a VPS) where participants mainly connect from the Internet, with the required LiveKit ports forwarded. May not work correctly for local participants if the router doesn't support NAT loopback/hairpinning.
+
+- **Local network and Internet** (`use_external_ip: true`, `advertise_internal_ip: true`): for a server behind a home/office router with port forwarding, reached both from the local network and from the Internet (mobile data, etc). This is usually the right choice if the router doesn't correctly support NAT loopback.\
+"""
+        help.fr = """\
+- **Réseau local uniquement** (`use_external_ip: false`, `advertise_internal_ip: false`) : pour les installations utilisées uniquement depuis un réseau local ou via un VPN. Le serveur n'est pas exposé sur Internet et aucun port LiveKit public n'est redirigé.
+
+- **Accès Internet uniquement** (`use_external_ip: true`, `advertise_internal_ip: false`) : pour un serveur avec une adresse IP publique (VPS par exemple) où les participants se connectent principalement depuis Internet, avec les ports LiveKit nécessaires redirigés. Peut ne pas fonctionner correctement pour les participants locaux si le routeur ne supporte pas le NAT loopback/hairpin.
+
+- **Réseau local et Internet** (`use_external_ip: true`, `advertise_internal_ip: true`) : pour un serveur derrière une box/un routeur avec redirection de ports, accessible à la fois depuis le réseau local et depuis Internet (4G, etc). C'est en général le bon choix si le routeur ne supporte pas correctement le NAT loopback.\
+"""

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -3,35 +3,41 @@
 version = "1.0"
 
 [main]
-name.en = "LiveKit network"
-name.fr = "Réseau LiveKit"
+# For today, we only offer options to define the use of livekit.
+# If later we would offer options for Meet directly, move items related to livekit
+# in a dedicated tab (so to a `[livekit]` section)
+name.en  = "LiveKit options"
+name.fr  = "Options pour LiveKit"
+help.en  = "LiveKit is the technical component handling the network communication during the video-conferencing"
+help.fr  = "LiveKit est le composant technique gérant la communication réseau durant une visio-conférence"
+services = [ "__APP__-livekit" ] # Restart livekit when applying configuration in this section
 
     [main.network]
     name.en = "Network mode"
     name.fr = "Mode réseau"
-    help.en = "Choose how LiveKit should advertise its address to participants, depending on how this server is reachable on the network. Changing this only restarts the LiveKit service."
-    help.fr = "Choisissez comment LiveKit doit annoncer son adresse aux participants, en fonction de la façon dont ce serveur est accessible sur le réseau. Ce changement ne redémarre que le service LiveKit."
+    help.en = "Choose how LiveKit should advertise its IP address to participants, depending on how this server is reachable on the network."
+    help.fr = "Choisissez comment LiveKit doit annoncer son adresse IP aux participants, en fonction de la façon dont ce serveur est accessible sur le réseau."
 
         [main.network.livekit_network_mode]
         ask.en = "LiveKit network mode"
-        ask.fr = "Mode réseau LiveKit"
+        ask.fr = "Mode réseau de LiveKit"
         type = "select"
         choices.local = "Local network only"
         choices.internet = "Internet access only"
         choices.both = "Local network and Internet"
-        default = "local"
+        default = "both"
         bind = "null"
         help.en = """\
-- **Local network only** (`use_external_ip: false`, `advertise_internal_ip: false`): for installations only used from a local network or through a VPN. The server isn't exposed to the Internet and no public LiveKit ports are forwarded.
+- **Local network only**: for installations only used from a local network or through a VPN. The server isn't exposed to the Internet and no public LiveKit ports are forwarded (livekit config: `use_external_ip: false`, `advertise_internal_ip: false`).
 
-- **Internet access only** (`use_external_ip: true`, `advertise_internal_ip: false`): for a server with a public IP address (e.g. a VPS) where participants mainly connect from the Internet, with the required LiveKit ports forwarded. May not work correctly for local participants if the router doesn't support NAT loopback/hairpinning.
+- **Internet access only**: for a server with a public IP address (e.g. a VPS) where participants mainly connect from the Internet, with the required LiveKit ports forwarded. May not work correctly for local participants if the router doesn't support NAT loopback/hairpinning (livekit config: `use_external_ip: true`, `advertise_internal_ip: false`).
 
-- **Local network and Internet** (`use_external_ip: true`, `advertise_internal_ip: true`): for a server behind a home/office router with port forwarding, reached both from the local network and from the Internet (mobile data, etc). This is usually the right choice if the router doesn't correctly support NAT loopback.\
+- **Local network and Internet**: for a server behind a home/office router with port forwarding, reached both from the local network and from the Internet (mobile data, etc). This is usually the right choice if the router doesn't correctly support NAT loopback (livekit config: `use_external_ip: true`, `advertise_internal_ip: true`).\
 """
         help.fr = """\
-- **Réseau local uniquement** (`use_external_ip: false`, `advertise_internal_ip: false`) : pour les installations utilisées uniquement depuis un réseau local ou via un VPN. Le serveur n'est pas exposé sur Internet et aucun port LiveKit public n'est redirigé.
+- **Local network only (Réseau local uniquement)** : pour les installations utilisées uniquement depuis un réseau local ou via un VPN. Le serveur n'est pas exposé sur Internet et aucun port LiveKit public n'est redirigé (configuration livekit : `use_external_ip: false`, `advertise_internal_ip: false`).
 
-- **Accès Internet uniquement** (`use_external_ip: true`, `advertise_internal_ip: false`) : pour un serveur avec une adresse IP publique (VPS par exemple) où les participants se connectent principalement depuis Internet, avec les ports LiveKit nécessaires redirigés. Peut ne pas fonctionner correctement pour les participants locaux si le routeur ne supporte pas le NAT loopback/hairpin.
+- **Internet access only (Accès Internet uniquement)** : pour un serveur avec une adresse IP publique (VPS par exemple) où les participants se connectent principalement depuis Internet, avec les ports LiveKit nécessaires redirigés. Peut ne pas fonctionner correctement pour les participants locaux si le routeur ne supporte pas le NAT loopback/hairpin (configuration livekit : `use_external_ip: true`, `advertise_internal_ip: false`).
 
-- **Réseau local et Internet** (`use_external_ip: true`, `advertise_internal_ip: true`) : pour un serveur derrière une box/un routeur avec redirection de ports, accessible à la fois depuis le réseau local et depuis Internet (4G, etc). C'est en général le bon choix si le routeur ne supporte pas correctement le NAT loopback.\
+- **Local network and Internet (Réseau local et Internet)** : pour un serveur derrière une box/un routeur avec redirection de ports, accessible à la fois depuis le réseau local et depuis Internet (4G, etc). C'est en général le bon choix si le routeur ne supporte pas correctement le NAT loopback (configuration livekit : `use_external_ip: true`, `advertise_internal_ip: true`).\
 """

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "La Suite - Meet"
 description.en = "Simple and Secure Video Conferencing"
 description.fr = "Solution simple et sécurisée de visioconférence"
 
-version = "1.25.2~ynh1"
+version = "1.25.2~ynh2"
 
 maintainers = ["fflorent", "rouja"]
 

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source _common.sh
+source /usr/share/yunohost/helpers
+
+ynh_abort_if_errors
+
+
+ynh_app_config_apply() {
+    if [ "${changed[livekit_network_mode]}:-false" == "true" ]; then
+        ynh_config_add --template="livekit.yaml.j2" --destination="$install_dir/livekit/livekit.yaml" --jinja
+        chmod 400 "$install_dir/livekit/livekit.yaml"
+        chown "$app:$app" "$install_dir/livekit/livekit.yaml"
+    fi
+
+    _ynh_app_config_apply
+}
+
+ynh_app_config_run $1

--- a/scripts/config
+++ b/scripts/config
@@ -13,7 +13,7 @@ ynh_abort_if_errors
 
 
 ynh_app_config_apply() {
-    if [ "${changed[livekit_network_mode]}:-false" == "true" ]; then
+    if [ "${changed[livekit_network_mode]:-false}" == "true" ]; then
         ynh_config_add --template="livekit.yaml.j2" --destination="$install_dir/livekit/livekit.yaml" --jinja
         chmod 400 "$install_dir/livekit/livekit.yaml"
         chown "$app:$app" "$install_dir/livekit/livekit.yaml"

--- a/scripts/install
+++ b/scripts/install
@@ -82,7 +82,7 @@ ynh_config_add --template="env" --destination="$install_dir/.env"
 chmod 400 "$install_dir/.env"
 chown "$app:$app" "$install_dir/.env"
 
-ynh_config_add --template="livekit.yaml" --destination="$install_dir/livekit/livekit.yaml"
+ynh_config_add --template="livekit.yaml.j2" --destination="$install_dir/livekit/livekit.yaml" --jinja
 chmod 400 "$install_dir/livekit/livekit.yaml"
 chown "$app:$app" "$install_dir/livekit/livekit.yaml"
 

--- a/scripts/install
+++ b/scripts/install
@@ -19,6 +19,7 @@ django_secret_key=$(ynh_string_random -l 32)
 ynh_app_setting_set --key=redis_db --value=$redis_db
 ynh_app_setting_set --key=livekit_secret_key --value=$livekit_secret_key
 ynh_app_setting_set --key=django_secret_key --value=$django_secret_key
+ynh_app_setting_set_default --key=livekit_network_mode --value=both
 
 #=================================================
 # FIND AND OPEN A PORT

--- a/scripts/restore
+++ b/scripts/restore
@@ -45,7 +45,7 @@ ynh_config_add --template="env" --destination="$install_dir/.env"
 chmod 400 "$install_dir/.env"
 chown "$app:$app" "$install_dir/.env"
 
-ynh_config_add --template="livekit.yaml" --destination="$install_dir/livekit/livekit.yaml"
+ynh_config_add --template="livekit.yaml.j2" --destination="$install_dir/livekit/livekit.yaml" --jinja
 chmod 400 "$install_dir/livekit/livekit.yaml"
 chown "$app:$app" "$install_dir/livekit/livekit.yaml"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -15,15 +15,22 @@ ynh_script_progression "Stopping $app's systemd service..."
 ynh_systemctl --service="$app" --action="stop"
 
 #=================================================
+# ENSURE DOWNWARD COMPATIBILITY
+#=================================================
+ynh_script_progression "Ensuring downward compatibility..."
+
+if ynh_app_upgrading_from_version_before_or_equal_to 0.1.23~ynh1; then
+    ynh_app_setting_delete --key=celery_redis_db
+fi
+
+ynh_app_setting_set_default --key=livekit_network_mode --value=both
+
+#=================================================
 # CONFIGURE FIREWALL
 #=================================================
 if ! yunohost firewall list | grep -q "\- 49152:65535"; then
     ynh_script_progression "Configuring firewall..."
     ynh_hide_warnings yunohost firewall allow UDP -4 49152:65535
-fi
-
-if ynh_app_upgrading_from_version_before_or_equal_to 0.1.23~ynh1; then
-    ynh_app_setting_delete --key=celery_redis_db
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -80,7 +80,7 @@ ynh_config_add --template="env" --destination="$install_dir/.env"
 chmod 400 "$install_dir/.env"
 chown "$app:$app" "$install_dir/.env"
 
-ynh_config_add --template="livekit.yaml" --destination="$install_dir/livekit/livekit.yaml"
+ynh_config_add --template="livekit.yaml.j2" --destination="$install_dir/livekit/livekit.yaml" --jinja
 chmod 400 "$install_dir/livekit/livekit.yaml"
 chown "$app:$app" "$install_dir/livekit/livekit.yaml"
 


### PR DESCRIPTION
## Problem

Fixes #108 

## Solution

Introduce an option in the config panel that configures the values for the livekit settings `use_external_ip` and `advertise_internal_ip`.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
